### PR TITLE
Remove token HDG

### DIFF
--- a/config/main.json
+++ b/config/main.json
@@ -881,8 +881,7 @@
     { "addr": "0xfeed1a53bd53ffe453d265fc6e70dd85f8e993b6", "name": "H2O", "decimals": 18 },
     { "addr": "0xff18dbc487b4c2e3222d115952babfda8ba52f5f", "name": "LIFE", "decimals": 18 },
     { "addr": "0xff3519eeeea3e76f1f699ccce5e23ee0bdda41ac", "name": "BCAP", "decimals": 0 },
-    { "addr": "0xffc63b9146967a1ba33066fb057ee3722221acf0", "name": "A", "decimals": 18 },
-    { "addr": "0xffe8196bc259e8dedc544d935786aa4709ec3e64", "name": "HDG", "decimals": 18 }
+    { "addr": "0xffc63b9146967a1ba33066fb057ee3722221acf0", "name": "A", "decimals": 18 }
   ],
   "defaultPair": { "token": "DAI", "base": "ETH" }
 }


### PR DESCRIPTION
It seems they are in the process of rebranding and issuing a new token in April, locked transactions with a tokenFrozenUntilBlock variable on their smart contact. All transactions are failing: https://etherscan.io/address/0xffe8196bc259e8dedc544d935786aa4709ec3e64